### PR TITLE
Formatting should hard fail in pre-push hook

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -7,7 +7,8 @@
     "dev": "npx http-server dist",
     "build": "npx gulp",
     "lint": "eslint src",
-    "format": "prettier --write 'src/**/*.js'"
+    "format": "prettier --write 'src/**/*.js'",
+    "format:check": "prettier --check 'src/**/*.js'"
   },
   "author": "T3D Contributors",
   "license": "GPL-3.0",

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -9,7 +9,8 @@
     "dev": "npx http-server dist",
     "build": "npx gulp",
     "lint": "eslint src",
-    "format": "prettier --write 'src/**/*.js'"
+    "format": "prettier --write 'src/**/*.js'",
+    "format:check": "prettier --check 'src/**/*.js'"
   },
   "devDependencies": {
     "browserify": "^16.5.1",

--- a/library/package.json
+++ b/library/package.json
@@ -5,7 +5,8 @@
     "build": "gulp",
     "version": "npm run build; git add build",
     "lint": "eslint src",
-    "format": "prettier --write 'src/**/*.js'"
+    "format": "prettier --write 'src/**/*.js'",
+    "format:check": "prettier --check 'src/**/*.js'"
   },
   "dependencies": {
     "DataStream.js": "github:kig/DataStream.js"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "lint": "lerna run --parallel lint",
     "format": "lerna run --parallel format",
+    "format:check": "lerna run --parallel format:check",
     "preversion": "git pull",
     "releaseMinor": "lerna version minor",
     "postinstall": "lerna exec npm install"
@@ -20,7 +21,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "npm run format; npm run lint"
+      "pre-push": "npm run format:check && npm run lint"
     }
   }
 }


### PR DESCRIPTION
We don't want to edit a commit without checking it so we should fail if on pre-push the formatter finds unformated code as the linter do.