### PR TITLE
[Explorer] Add scroll events handling for movement speed

### DIFF
--- a/examples/src/MapExplorer/index.js
+++ b/examples/src/MapExplorer/index.js
@@ -143,12 +143,11 @@ function loadCollModels() {
 
 function onMouseWheel(event) {
   let newSpeed;
-  if (event.originalEvent.deltaY > 0) {
+  if (event.originalEvent.deltaY < 0) {
     newSpeed = Math.min(mapRenderer.getMovementSpeed() + 100, 10000);
   } else {
     newSpeed = Math.max(mapRenderer.getMovementSpeed() - 100, 500);
   }
   mapRenderer.setMovementSpeed(newSpeed);
   $("#mvntSpeedRange").val(newSpeed);
-  console.log(newSpeed);
 }

--- a/explorer/src/ui.js
+++ b/explorer/src/ui.js
@@ -21,8 +21,10 @@ class UI {
     this.setupMapChoice();
     this.setupMapExplorer();
 
-    this.appRenderer.setMovementSpeed(parseInt($("#mvntSpeedRange").val()));
+    this.appRenderer.setMovementSpeed(parseInt($("#mvntSpeedRange").val(), 10));
     this.appRenderer.setFogDistance(parseInt($("#fogRange").val(), 10));
+
+    $("canvas").on("wheel", (event) => this.onMouseWheel(event));
   }
 
   /*
@@ -116,6 +118,16 @@ class UI {
         this.onFileScanDone();
       });
     });
+  }
+
+  onMouseWheel(event) {
+    const newSpeed =
+      event.originalEvent.deltaY < 0
+        ? Math.min(this.appRenderer.movementSpeed + 100, 10000)
+        : Math.max(this.appRenderer.movementSpeed - 100, 500);
+
+    this.appRenderer.setMovementSpeed(newSpeed);
+    $("#mvntSpeedRange").val(newSpeed);
   }
 
   /* UTILS */


### PR DESCRIPTION
Scrollwheel will now change your speed in the 3d view of the explorer.

Minor change:
Reversed the scroll direction for the map explorer (where it was already implemented)